### PR TITLE
Fix/fix sign in

### DIFF
--- a/tmh_registry/users/api/serializers.py
+++ b/tmh_registry/users/api/serializers.py
@@ -40,7 +40,7 @@ class SignInSerializer(serializers.Serializer):
     Serializer responsible for input validation of sign in view
     """
 
-    email = serializers.EmailField(required=True)
+    username = serializers.CharField(required=True)
     password = serializers.CharField(required=True)
 
     def update(self, instance, validated_data):  # pragma: no cover

--- a/tmh_registry/users/api/views.py
+++ b/tmh_registry/users/api/views.py
@@ -91,16 +91,16 @@ class SignInView(BaseUserManagementView):
         """
         serializer = self.get_valid_serializer(request)
 
-        if not authenticate(
-            username=serializer.data.get("email"),
+        user = authenticate(
+            username=serializer.data.get("username"),
             password=serializer.data.get("password"),
-        ):
+        )
+
+        if not user:
             raise Exception(
-                "The email and password provided are invalid",
+                "The username and/or password provided are invalid",
                 status.HTTP_400_BAD_REQUEST,
             )
-
-        user = self.get_user_from_email(serializer.data.get("email"))
 
         token = Token.objects.get_or_create(user=user)[0]
         return_serializer = SignInResponseSerializer(

--- a/tmh_registry/users/tests/test_views.py
+++ b/tmh_registry/users/tests/test_views.py
@@ -15,6 +15,7 @@ class BaseUserManagementTestView(ABC):
     def setUpClass(cls) -> None:
         super(BaseUserManagementTestView, cls).setUpClass()
         cls.request_factory = RequestFactory()
+        cls.username = "username"
         cls.email = "email@email.com"
         cls.password = "password"
         cls.code = "code"
@@ -39,9 +40,8 @@ class TestSignInView(BaseUserManagementTestView, TestCase):
     @patch("tmh_registry.users.api.views." "authenticate")
     def test_authentication_error(self, authenticate):
         data = {
-            "email": self.email,
+            "username": self.username,
             "password": self.password,
-            "code": self.code,
         }
         request = self.request_factory.post(
             self.url, data, content_type="application/json"
@@ -51,15 +51,14 @@ class TestSignInView(BaseUserManagementTestView, TestCase):
         with self.assertRaises(Exception):
             self.view.post(request)
             authenticate.assert_called_once_with(
-                username=self.email, password=self.password
+                username=self.username, password=self.password
             )
 
     @patch("tmh_registry.users.api.views." "authenticate")
     def test_user_not_found_error(self, authenticate):
         data = {
-            "email": self.email,
+            "username": self.username,
             "password": self.password,
-            "code": self.code,
         }
 
         request = self.request_factory.post(
@@ -70,20 +69,19 @@ class TestSignInView(BaseUserManagementTestView, TestCase):
         with self.assertRaises(Exception):
             self.view.post(request)
             authenticate.assert_called_once_with(
-                username=self.email, password=self.password
+                username=self.username, password=self.password
             )
 
     @patch("tmh_registry.users.api.views." "authenticate")
     def test_sunny_day(self, authenticate):
-        User.objects.create(
-            username=self.email, email=self.email, password=self.password
+        user = User.objects.create(
+            username=self.username, email=self.email, password=self.password
         )
         data = {
-            "email": self.email,
+            "username": self.username,
             "password": self.password,
-            "code": self.code,
         }
-        authenticate.return_value = True
+        authenticate.return_value = user
         request = self.request_factory.post(
             self.url, data, content_type="application/json"
         )
@@ -92,5 +90,5 @@ class TestSignInView(BaseUserManagementTestView, TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         authenticate.assert_called_once_with(
-            username=self.email, password=self.password
+            username=self.username, password=self.password
         )


### PR DESCRIPTION
## Description

I made changes so the `/sign-in/` endpoint gets `username` instead of `email` as input.

## Checklist

<!-- Please check everything that applies: -->

- [x] I have reviewed my code and checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation (**SwaggerHub**, **README.md**, **Wiki**, etc.) for the changes I have made
