### PR TITLE
Password change endpoint

### DIFF
--- a/tmh_registry/registry/urls.py
+++ b/tmh_registry/registry/urls.py
@@ -21,3 +21,6 @@ router.register(r"follow-ups", FollowUpViewset)
 urlpatterns = [
     path("", include(router.urls)),
 ]
+
+# @ todo medical personel required (????)
+

--- a/tmh_registry/users/api/serializers.py
+++ b/tmh_registry/users/api/serializers.py
@@ -1,7 +1,8 @@
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model, password_validation
 from django.db import transaction
+from django.utils.translation import gettext_lazy as _
 from rest_framework.fields import CharField
-from rest_framework.serializers import ModelSerializer, Serializer
+from rest_framework.serializers import ModelSerializer, Serializer, ValidationError
 
 from ..models import MedicalPersonnel
 
@@ -75,3 +76,29 @@ class SignInResponseSerializer(Serializer):
 
     def create(self, validated_data):  # pragma: no cover
         pass
+
+class ChangePasswordSerializer(Serializer):
+    old_password = CharField(max_length=128, write_only=True, required=True)
+    new_password1 = CharField(max_length=128, write_only=True, required=True)
+    new_password2 = CharField(max_length=128, write_only=True, required=True)
+
+    def validate_old_password(self, value):
+        user = self.context['request'].user
+        if not user.check_password(value):
+            raise ValidationError(
+                _('Your old password was entered incorrectly. Please enter it again.')
+            )
+        return value
+
+    def validate(self, data):
+        if data['new_password1'] != data['new_password2']:
+            raise ValidationError({'new_password2': _("The two password fields didn't match.")})
+        password_validation.validate_password(data['new_password1'], self.context['request'].user)
+        return data
+
+    def save(self, **kwargs):
+        password = self.validated_data['new_password1']
+        user = self.context['request'].user
+        user.set_password(password)
+        user.save()
+        return user

--- a/tmh_registry/users/urls.py
+++ b/tmh_registry/users/urls.py
@@ -1,7 +1,7 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from tmh_registry.users.api.views import SignInView
+from tmh_registry.users.api.views import SignInView, ChangePasswordView
 from tmh_registry.users.api.viewsets import MedicalPersonnelViewSet
 
 router = DefaultRouter()
@@ -10,4 +10,5 @@ router.register(r"medical-personnel", MedicalPersonnelViewSet)
 urlpatterns = [
     path(r"sign-in/", SignInView.as_view()),
     path(r"", include(router.urls)),
+    path(r"change-password/", ChangePasswordView.as_view())
 ]


### PR DESCRIPTION
## Description

A new endpoint that accepts PUT and PATCH HTTP methods with request body:

`{
    "old_password": "oldpassword",
    "new_password1": "newpassword",
    "new_password2": "newpassword"
}`

And returns an HTTP 200 response and the body contains the new Token (the previous token will be deleted):
{
    "token": "ea1be0b05cb95ff20fb27a3d06534fe6285eb19e"
}

[https://tmh-registry-api-staging.herokuapp.com/swagger/](https://tmh-registry-api-staging.herokuapp.com/swagger/)